### PR TITLE
bumping libxmljs to ^0.12.0 for node v0.11 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-xml",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A naive XML parser and builder based on libxmljs",
   "main": "XML.js",
   "scripts": {
@@ -19,7 +19,7 @@
   "author": "Jerome Touffe-Blin <jtblin@gmail.com>",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "libxmljs": "~0.9.0"
+    "libxmljs": "^0.12.0"
   },
   "devDependencies": {
     "mocha": "~1.18.2",


### PR DESCRIPTION
This is required for building on node v0.11 and most likely v0.12 when it is released.
